### PR TITLE
Fixed reference of Radworks Treasury

### DIFF
--- a/proposals/fund_grants_2024.proposal
+++ b/proposals/fund_grants_2024.proposal
@@ -2,8 +2,8 @@
 
 If executed, this proposal will:
 
-1. Transfer 1,050,000 USDC from the Radicle Foundation to the Radworks Grant Program's multi-sig
-2. Transfer 100,000 RAD from the Radicle Foundation to the Radworks Grant Program's multi-sig
+1. Transfer 1,050,000 USDC from the Radworks Treasury to the Radworks Grant Program's multi-sig
+2. Transfer 100,000 RAD from the Radworks Treasury to the Radworks Grant Program's multi-sig
 
 **How was this proposal discussed?**
 


### PR DESCRIPTION
Corrected "Radicle Foundation" to "Radworks Treasury" per Ange's comment below

https://community.radworks.org/t/discussion-rgp-20-grants-org-proposal-2024-v2/3455/6